### PR TITLE
Allow any field that matches the supplied pattern to ignore

### DIFF
--- a/src/main/java/com/shazam/shazamcrest/matcher/CustomisableMatcher.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/CustomisableMatcher.java
@@ -46,4 +46,16 @@ public interface CustomisableMatcher<T> extends Matcher<T> {
 	 * @return the instance of the matcher
 	 */
 	<V> CustomisableMatcher<T> with(String fieldPath, Matcher<V> matcher);
+
+	/**
+	 * Specify a pattern of fieldattributes to ignore. Any bean property with a name that
+	 * matches the supplied pattern will be ignored.
+	 * 
+	 * Usuful all fields with a certain name. Example:
+	 * <pre>assertThat(myBean, sameBeanAs(
+                        myResultBean).ignoring(is("mutationdate")).ignoring(is("version")))</pre>
+	 * @param pattern
+	 * @return
+	 */
+    CustomisableMatcher<T> ignoring(Matcher<String> pattern);
 }

--- a/src/main/java/com/shazam/shazamcrest/matcher/DiagnosingCustomisableMatcher.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/DiagnosingCustomisableMatcher.java
@@ -10,8 +10,8 @@
 package com.shazam.shazamcrest.matcher;
 
 import static com.shazam.shazamcrest.BeanFinder.findBeanAt;
-import static com.shazam.shazamcrest.FieldsIgnorer.MARKER;
 import static com.shazam.shazamcrest.CyclicReferenceDetector.getClassesWithCircularReferences;
+import static com.shazam.shazamcrest.FieldsIgnorer.MARKER;
 import static com.shazam.shazamcrest.FieldsIgnorer.findPaths;
 import static com.shazam.shazamcrest.matcher.GsonProvider.gson;
 
@@ -23,15 +23,14 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.shazam.shazamcrest.ComparisonDescription;
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
 import org.json.JSONException;
 import org.skyscreamer.jsonassert.JSONAssert;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.shazam.shazamcrest.ComparisonDescription;
 
 /**
  * Extends the functionalities of {@link DiagnosingMatcher} with the possibility to specify fields and object types to
@@ -41,6 +40,7 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 	private final Set<String> pathsToIgnore = new HashSet<String>();
 	private final Map<String, Matcher<?>> customMatchers = new HashMap<String, Matcher<?>>();
 	protected final List<Class<?>> typesToIgnore = new ArrayList<Class<?>>();
+	protected final List<Matcher<String>> patternsToIgnore = new ArrayList<Matcher<String>>();
     protected final Set<Class<?>> circularReferenceTypes = new HashSet<Class<?>>();
 	protected final T expected;
 
@@ -50,7 +50,7 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 
 	@Override
 	public void describeTo(Description description) {
-		Gson gson = gson(typesToIgnore, circularReferenceTypes);
+		Gson gson = gson(typesToIgnore, patternsToIgnore, circularReferenceTypes);
 		description.appendText(filterJson(gson, expected));
 		for (String fieldPath : customMatchers.keySet()) {
 			description.appendText("\nand ")
@@ -63,7 +63,7 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 	protected boolean matches(Object actual, Description mismatchDescription) {
         circularReferenceTypes.addAll(getClassesWithCircularReferences(actual));
         circularReferenceTypes.addAll(getClassesWithCircularReferences(expected));
-		Gson gson = gson(typesToIgnore, circularReferenceTypes);
+		Gson gson = gson(typesToIgnore, patternsToIgnore, circularReferenceTypes);
 		
 		if (!areCustomMatchersMatching(actual, mismatchDescription, gson)) {
 			return false;
@@ -105,6 +105,12 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 	public CustomisableMatcher<T> ignoring(Class<?> clazz) {
 		typesToIgnore.add(clazz);
 		return this;
+	}
+	
+	@Override
+	public CustomisableMatcher<T> ignoring(Matcher<String> pattern) {
+	    patternsToIgnore.add(pattern);
+	    return this;
 	}
 
     @Override

--- a/src/main/java/com/shazam/shazamcrest/matcher/NullMatcher.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/NullMatcher.java
@@ -27,7 +27,7 @@ class NullMatcher<T> extends DiagnosingCustomisableMatcher<T> {
     protected boolean matches(Object actual, Description mismatchDescription) {
         if (actual != null) {
             circularReferenceTypes.addAll(getClassesWithCircularReferences(actual));
-            String actualJson = gson(typesToIgnore, circularReferenceTypes).toJson(actual);
+            String actualJson = gson(typesToIgnore, patternsToIgnore, circularReferenceTypes).toJson(actual);
             return appendMismatchDescription(mismatchDescription, "null", actualJson, "actual is not null");
         }
         return true;

--- a/src/test/java/com/shazam/shazamcrest/MatcherAssertIgnoringPatternTest.java
+++ b/src/test/java/com/shazam/shazamcrest/MatcherAssertIgnoringPatternTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 Shazam Entertainment Limited
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * 
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.shazam.shazamcrest;
+
+import static com.shazam.shazamcrest.MatcherAssert.assertThat;
+import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
+import static com.shazam.shazamcrest.model.ParentBean.Builder.parent;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import com.shazam.shazamcrest.model.ParentBean;
+import org.junit.Test;
+
+/**
+ * Tests for {@link MatcherAssert} which verify that fields that match supplied pattern are ignored.
+ */
+public class MatcherAssertIgnoringPatternTest {
+
+	@Test
+	public void ignoresByExactName() {
+	    ParentBean expected = parent().childBean("value3", 123).childBean("value3", 123).build();
+	    ParentBean actual = parent().childBean("value3", 123).childBean("value3a", 123).build();;
+
+		assertThat(actual, sameBeanAs(expected).ignoring(is("childString")));
+	}
+	
+    @Test
+    public void ignoresAny() {
+        ParentBean expected = parent().childBean("value3", 123).childBean("value3", 123).build();
+        ParentBean actual = parent().childBean("value3", 1235).childBean("value3a", 123).build();;
+
+        assertThat(actual, sameBeanAs(expected).ignoring(containsString("child")));
+    }
+}


### PR DESCRIPTION
Hello,

First, of alll, thanks for your nice matcher!
In our project we have a few default fields in beans we always want to ignore, like version and mutationdate. I've added an extra ignoring method, that allows properties to be ignored based on a matcher. This way I can ignore all attributes that equal version.

Kind regards,

Gerbrand van Dieijen