### PR TITLE
Added ComparisonException diagnostics with message rather than JSONException diagnostics for when actual is null in sameBeanAs

### DIFF
--- a/src/main/java/com/shazam/shazamcrest/matcher/DiagnosingCustomisableMatcher.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/DiagnosingCustomisableMatcher.java
@@ -9,11 +9,14 @@
  */
 package com.shazam.shazamcrest.matcher;
 
-import static com.shazam.shazamcrest.BeanFinder.findBeanAt;
-import static com.shazam.shazamcrest.FieldsIgnorer.MARKER;
-import static com.shazam.shazamcrest.CyclicReferenceDetector.getClassesWithCircularReferences;
-import static com.shazam.shazamcrest.FieldsIgnorer.findPaths;
-import static com.shazam.shazamcrest.matcher.GsonProvider.gson;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.shazam.shazamcrest.ComparisonDescription;
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
+import org.hamcrest.Matcher;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,15 +26,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.hamcrest.Description;
-import org.hamcrest.DiagnosingMatcher;
-import org.hamcrest.Matcher;
-import org.json.JSONException;
-import org.skyscreamer.jsonassert.JSONAssert;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.shazam.shazamcrest.ComparisonDescription;
+import static com.shazam.shazamcrest.BeanFinder.findBeanAt;
+import static com.shazam.shazamcrest.CyclicReferenceDetector.getClassesWithCircularReferences;
+import static com.shazam.shazamcrest.FieldsIgnorer.MARKER;
+import static com.shazam.shazamcrest.FieldsIgnorer.findPaths;
+import static com.shazam.shazamcrest.matcher.GsonProvider.gson;
 
 /**
  * Extends the functionalities of {@link DiagnosingMatcher} with the possibility to specify fields and object types to
@@ -70,9 +69,14 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 		}
 		
 		String expectedJson = filterJson(gson, expected);
+
+		if (actual == null) {
+			return appendMismatchDescription(mismatchDescription, expectedJson, "null", "actual was null");
+		}
+
 		String actualJson = filterJson(gson, actual);
 
-		return assertEquals(expectedJson, actualJson, mismatchDescription, gson);
+		return assertEquals(expectedJson, actualJson, mismatchDescription);
 	}
 
 	private boolean areCustomMatchersMatching(Object actual, Description mismatchDescription, Gson gson) {
@@ -125,7 +129,7 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 		return false;
 	}
 
-	private boolean assertEquals(final String expectedJson, String actualJson, Description mismatchDescription, Gson gson) {
+	private boolean assertEquals(final String expectedJson, String actualJson, Description mismatchDescription) {
 		try {
 			JSONAssert.assertEquals(expectedJson, actualJson, true);
 		} catch (AssertionError e) {

--- a/src/test/java/com/shazam/shazamcrest/MatcherAssertFailureDiagnosticTest.java
+++ b/src/test/java/com/shazam/shazamcrest/MatcherAssertFailureDiagnosticTest.java
@@ -9,6 +9,13 @@
  */
 package com.shazam.shazamcrest;
 
+import com.shazam.shazamcrest.model.Bean;
+import org.hamcrest.Matcher;
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+
+import java.util.Map;
+
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
 import static com.shazam.shazamcrest.FieldsIgnorer.MARKER;
@@ -27,14 +34,6 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.fail;
 
-import java.util.Map;
-
-import org.hamcrest.Matcher;
-import org.junit.ComparisonFailure;
-import org.junit.Test;
-
-import com.shazam.shazamcrest.model.Bean;
-
 /**
  * MatcherAssert tests checking the diagnostic of the failure cases
  */
@@ -51,6 +50,19 @@ public class MatcherAssertFailureDiagnosticTest {
 			fail("Exception expected");
 		} catch (ComparisonFailure e) {
 			checkThat(e, expected(is(notANullValue())), actual(is(equalTo("null"))));
+		}
+	}
+
+	@Test
+	public void includesCorrectMessageWhenActualIsNull() {
+		Bean expected = bean().string("value1").integer(1).build();
+		Bean actual = null;
+
+		try {
+			assertThat(actual, sameBeanAs(expected));
+			fail("Exception expected");
+		} catch (ComparisonFailure e) {
+			checkThat(e, message(is(equalTo("actual was null expected:<[{\n  \"string\": \"value1\",\n  \"integer\": 1\n}]> but was:<[null]>"))));
 		}
 	}
 


### PR DESCRIPTION
When the actual bean being compared is null using `sameBeanAs` for example:

```java
assertThat(null, sameBeanAs(expectedNonNullBean));
```
you would get a ComparisonFailure like:
```
org.junit.ComparisonFailure: Unparsable JSON string: null   <Click to see difference>
```

This message does not say what was unparsable and doesn't match up nicely with the descriptive message we have for the opposite case where expected is null:
```java
assertThat(actualNonNullBean, sameBeanAs(null));
```
```
org.junit.ComparisonFailure: actual is not null   <Click to see difference>
```

This change would allow the following message to be displayed when the actual is null:
```
org.junit.ComparisonFailure: actual was null  <Click to see difference>
```

This is particularly useful when you are writing a failing test and your implementation returns null, you get a nice message.



