### PR TITLE
added comparison of milliseconds when java.util.Date is compared

### DIFF
--- a/src/main/java/com/shazam/shazamcrest/matcher/GsonProvider.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/GsonProvider.java
@@ -15,7 +15,9 @@ import static org.apache.commons.lang3.ClassUtils.isPrimitiveOrWrapper;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
+import java.text.SimpleDateFormat;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -33,6 +35,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.graph.GraphAdapterBuilder;
@@ -45,6 +48,9 @@ import org.hamcrest.Matcher;
  */
 @SuppressWarnings("rawtypes")
 class GsonProvider {
+
+	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("MMM d, yyyy hh:mm:ss.SSS aa");
+
 	/**
      * Returns a {@link Gson} instance containing {@link ExclusionStrategy} based on the object types to ignore during
      * serialisation.
@@ -63,9 +69,9 @@ class GsonProvider {
         gsonBuilder.registerTypeAdapter(Optional.class, new OptionalSerializer());
 
         registerSetSerialisation(gsonBuilder);
-        
         registerMapSerialisation(gsonBuilder);
-        
+        registerDateSerialisation(gsonBuilder);
+
         markSetAndMapFields(gsonBuilder);
         
         registerExclusionStrategies(gsonBuilder, typesToIgnore, fieldsToIgnore);
@@ -128,6 +134,15 @@ class GsonProvider {
 
         		Set<Object> orderedSet = orderSetByElementsJsonRepresentation(set, gson);
         		return arrayOfObjectsOrderedByTheirJsonRepresentation(gson, orderedSet);
+        	}
+        });
+	}
+
+	private static void registerDateSerialisation(final GsonBuilder gsonBuilder) {
+		gsonBuilder.registerTypeHierarchyAdapter(Date.class, new JsonSerializer<Date>() {
+        	@Override
+        	public JsonElement serialize(Date date, Type type, JsonSerializationContext context) {
+        		return new JsonPrimitive(DATE_FORMAT.format(date));
         	}
         });
 	}

--- a/src/test/java/com/shazam/shazamcrest/MatcherAssertDateTest.java
+++ b/src/test/java/com/shazam/shazamcrest/MatcherAssertDateTest.java
@@ -1,0 +1,59 @@
+package com.shazam.shazamcrest;
+
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static com.shazam.shazamcrest.MatcherAssert.assertThat;
+import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
+import static com.shazam.shazamcrest.matchers.ComparisonFailureMatchers.checkThat;
+import static com.shazam.shazamcrest.matchers.ComparisonFailureMatchers.message;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.fail;
+
+public class MatcherAssertDateTest {
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss.SSS");
+
+    @Test
+    public void doesNothingWhenDatesAreTheSame() throws ParseException {
+        Date one = DATE_FORMAT.parse("01/01/2016 10:01:23.456");
+        Date two = DATE_FORMAT.parse("01/01/2016 10:01:23.456");
+
+        assertThat(one, sameBeanAs(two));
+    }
+
+    @Test(expected = ComparisonFailure.class)
+    public void throwsComparisonFailureWhenDatesDifferByMillisecondsOnly() throws ParseException {
+        Date one = DATE_FORMAT.parse("01/01/2016 10:00:00.300");
+        Date two = DATE_FORMAT.parse("01/01/2016 10:00:00.500");
+
+        assertThat(one, sameBeanAs(two));
+    }
+
+    @Test(expected = ComparisonFailure.class)
+    public void throwsComparisonFailureWhenDatesDifferMinutesOnly() throws ParseException {
+        Date one = DATE_FORMAT.parse("01/01/2016 10:00:00.000");
+        Date two = DATE_FORMAT.parse("01/01/2016 10:00:01.000");
+
+        assertThat(one, sameBeanAs(two));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void showsMillisecondsOnDates() throws ParseException {
+        Date one = DATE_FORMAT.parse("02/01/2016 23:59:59.999");
+        Date two = DATE_FORMAT.parse("11/10/966 00:00:00.000");
+        try {
+            assertThat(one, sameBeanAs(two));
+        } catch (ComparisonFailure e) {
+            checkThat(e, message(containsString("[Oct 11, 0966 12:00:00.000 A]M")), message(containsString("[Jan 2, 2016 11:59:59.999 P]M")));
+            return;
+        }
+        fail("Exception expected but not thrown");
+    }
+
+}


### PR DESCRIPTION
Fix for issue #21 - "Problem with Date and equals method".

The new format contains ".SSS" after seconds, otherwise it is unchanged.